### PR TITLE
Adds support for parsing stored procedures and functions in MySQL

### DIFF
--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/SqlScriptMigrationTask.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/SqlScriptMigrationTask.java
@@ -401,6 +401,12 @@ public class SqlScriptMigrationTask extends MigrationTaskSupport
         {
             return true;
         }
+        if ("mysql".equals(databaseType)
+                && (currentStatement.startsWith("create procedure")
+                        || currentStatement.startsWith("create function")))
+        {
+            return true;
+        }
         
         return false;
     }


### PR DESCRIPTION
This change allows for MySQL stored procedures and stored functions to be used in sql scripts.  It just recognizes "create procedure" and "create function" statements as the beginning of stored procedure and function statements so that the entire statement is sent over the wire as one full statement, not delimited by semi-colons.
