### PR TITLE
Updates dbunit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,9 +241,9 @@
     </dependency>
 
     <dependency>
-      <groupId>dbunit</groupId>
+      <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>[2.1,)</version>
+      <version>[2.2,)</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
The dbunit dependency coordinate has changed from a groupId of
`dbunit` to `org.dbunit`.  In addition, the minimal version in
the new group is 2.2.  This change encompasses both updates.

I made this change, because other projects that use newer versions
of dbunit can get conflicts if they depend on `org.dbunit` and the
autopatcher brings in a version of `dbunit`.
