### PR TITLE
adding in mvn shade to produce shaded jar containing all dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,29 @@
           </archive>
         </configuration>
       </plugin>
-      
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>1.4</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedClassifierName>shaded</shadedClassifierName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>com.tacitknowledge.util.migration.jdbc.StandaloneMigrationLauncher</mainClass>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>      
     </plugins>
   </build>
 


### PR DESCRIPTION
Added in maven-shade-plugin so that there's a build artifact which contains all dependencies. This should be useful for creating a script to invoke autopatch.
