### PR TITLE
Fixes for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,9 @@
         <contributor>
             <name>Hemri Herrera</name>
         </contributor>
+        <contributor>
+            <name>Marco Rangel</name>
+        </contributor>
     </contributors>
 
     <build>
@@ -130,6 +133,14 @@
 					<target>${target.jdk}</target>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
@@ -19,6 +19,8 @@ import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 /**
  * A partial <code>DataSource</code> implementation that simply wraps a single,
@@ -90,6 +92,13 @@ public class ConnectionWrapperDataSource implements DataSource
      */
     public int getLoginTimeout() throws UnsupportedOperationException
     {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
     }
 

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
@@ -19,6 +19,8 @@ import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 /**
  * A partial <code>DataSource</code> implementation that can be used in environments
@@ -113,6 +115,13 @@ public class NonPooledDataSource implements DataSource
      */
     public int getLoginTimeout() throws UnsupportedOperationException
     {
+        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
     }
 


### PR DESCRIPTION
Added a couple of unimplemented methods and ignored Xdoclint (a Javadoc format checker that runs automatically with Java 8) that was raising erros in the build because of the current documentation. For more information about the Xdoclint issues:

http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete

http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html
