### PR TITLE
Updated to work with Java 7 and Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
+  - oraclejdk7
   - openjdk6
 

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
@@ -19,6 +19,8 @@ import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 /**
  * A partial <code>DataSource</code> implementation that simply wraps a single,
@@ -91,6 +93,14 @@ public class ConnectionWrapperDataSource implements DataSource
     public int getLoginTimeout() throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     /**

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/ConnectionWrapperDataSource.java
@@ -98,7 +98,6 @@ public class ConnectionWrapperDataSource implements DataSource
     /**
      * {@inheritDoc}
      */
-    @Override
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
@@ -121,7 +121,6 @@ public class NonPooledDataSource implements DataSource
     /**
      * {@inheritDoc}
      */
-    @Override
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }

--- a/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
+++ b/src/main/java/com/tacitknowledge/util/migration/jdbc/util/NonPooledDataSource.java
@@ -19,6 +19,8 @@ import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 /**
  * A partial <code>DataSource</code> implementation that can be used in environments
@@ -114,6 +116,14 @@ public class NonPooledDataSource implements DataSource
     public int getLoginTimeout() throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_EXCEPTION_MSG);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     /**


### PR DESCRIPTION
I'm getting ready to troubleshoot something a user reported on the autopatch-users list and found that Autopatch wouldn't compile with his Java version (8). It now builds and tests successfully on 6, 7, and 8. Travis CI should start running a separate CI build for each Java version as well.
